### PR TITLE
fixes, Comments, References, Defaults to constant, Timestamp updates

### DIFF
--- a/autogen.js
+++ b/autogen.js
@@ -91,7 +91,11 @@ function create_table(orm, table) {
 	var lines = [];
 	lines.push(mysql.format('CREATE TABLE IF NOT EXISTS ?? (', table.$name));
 	lines.push(indent(columns.join(',\n')));
+	if (table.$comment && table.$comment.length) {
+		lines.push(') COMMENT='+mysql.escape(table.$comment)+';');
+	} else {
 	lines.push(');');
+	}
 	return lines.join('\n');
 }
 

--- a/autogen.js
+++ b/autogen.js
@@ -132,7 +132,15 @@ function column_definition(orm, field) {
 		field.type,
 		field.auto_increment && 'AUTO_INCREMENT',
 		!field.nullable && 'NOT NULL',
-		field.default && ('DEFAULT ' + mysql.escape(def))
+		field.default && (
+			_.isString(def) && def.charAt(0)=='$' && ('DEFAULT ' + def.substring(1))
+			|| ('DEFAULT ' + mysql.escape(def))
+			),
+		field.update && (
+			_.isString(field.update) && field.update.charAt(0)=='$' && ('ON UPDATE ' + field.update.substring(1))
+			|| ('ON UPDATE ' + mysql.escape(field.update))
+			),
+		field.comment && ('COMMENT ' + mysql.escape(field.comment))
 	]).compact().join(' '));
 	return lines.join(',\n');
 };

--- a/initialise-schema.js
+++ b/initialise-schema.js
@@ -106,7 +106,7 @@ function expand_field_shorthand_definition(orm, fullname, def) {
 	if (f.length === 0) {
 		return orm.error(err('No type found'));
 	}
-	field = {};
+	var field = {};
 	field.type = f.shift();
 	field.unique = flag('unique');
 	field.index = flag('index');

--- a/parse-schema.js
+++ b/parse-schema.js
@@ -56,6 +56,10 @@ function parse_schema(orm) {
 	/* Process fields */
 	names(schema).forEach(function parse_table(tableName) {
 		var table = schema[tableName];
+		/* Add referenced fields */
+		if (table.$ref && table.$ref.length) {
+			_.defaults(table, schema[table.$ref]);
+		}
 		names(table).forEach(function parse_field(fieldName) {
 			var field = table[fieldName];
 			/* Resolve aliases */

--- a/parse-schema.js
+++ b/parse-schema.js
@@ -134,6 +134,7 @@ function parse_schema(orm) {
 	/* Generate FK constraint names */
 	all_refs.forEach(function (field) {
 		field.$fkname = [
+				field.$table.$name,
 				field.$name, 'fk', field.references.$table.$name,
 				field.references.$name
 			].join('_');


### PR DESCRIPTION
## Fixes:
- in strict mode the interpreter requires that all variable must be declared
- on FK constraint names generation I was getting duplicate errors on tables like this
```javascript
{
    estado: {},  // it will create *id* automatically
    car: { estado_id: ':estado' }, // will generate estado_id_estado_id as FK
    ship: { estado_id: ':estado' }, // will generate estado_id_estado_id again !!
}
```
## new Table features:
#### $ref:
Allows using object base extension, like inheritance in OOP
#### $comment:
Allows to document the table and store that on the database

This example:
```javascript
{
    address: { street: 'varchar(200)', number: 'integer', apt: 'varchar(200)' },
    delivery: { $ref: 'address', zipcode: 'varchar(10)' },
    international: { $ref: 'address', $comment: 'recommended for international orders', country: 'varchar(2)', street:'text' }
}
```
will generate this SQL:
```sql
CREATE TABLE IF NOT EXISTS `address` (
        `street` varchar(200) NOT NULL,
        `number` integer NOT NULL,
        `apt` varchar(200) NOT NULL,
        `id` INTEGER AUTO_INCREMENT NOT NULL,
        PRIMARY KEY (`id`)
    );
CREATE TABLE IF NOT EXISTS `delivery` (
        `zipcode` varchar(10) NOT NULL,
        `id` INTEGER AUTO_INCREMENT NOT NULL,
        `street` varchar(200) NOT NULL,
        `number` integer NOT NULL,
        `apt` varchar(200) NOT NULL,
        PRIMARY KEY (`id`)
    );
CREATE TABLE IF NOT EXISTS `international` (
        `country` varchar(2) NOT NULL,
        `street` text NOT NULL,
        `id` INTEGER AUTO_INCREMENT NOT NULL,
        `number` integer NOT NULL,
        `apt` varchar(200) NOT NULL,
        PRIMARY KEY (`id`)
    ) COMMENT='recommended for international orders';
```

## new Field features:
#### comment:
Allows to store documentation on the database about the field
#### update:
Mostly used for TIMESTAMP datatype, it generates an ON UPDATE sentence
#### constants on DEFAULT and UPDATE
By prepending a **$** symbol on the string default value, the value will be used as a CONSTANT without escaping, which allows the use of CURRENT_TIMESTAMP and the like; it can be used on **default** and **update** properties

The following example, demonstrates the use of the previous features:
```javascript
{
    basic: {
        updated_on: { 
            type: 'timestamp', 
            default: '$CURRENT_TIMESTAMP', 
            update: '$CURRENT_TIMESTAMP',
            comment: 'last time that the party was allowed on this place'
        },
        party: 'varchar(100)',
        active: { type: 'integer', default: 1 }
	}
}
```
which generates the corresponding SQL code:
```sql
CREATE TABLE IF NOT EXISTS `basic` (
        `updated_on` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'last time that the party was allowed on this place',
        `party` varchar(100) NOT NULL,
        `active` integer NOT NULL DEFAULT 1,
        `id` INTEGER AUTO_INCREMENT NOT NULL,
        PRIMARY KEY (`id`)
);
```
